### PR TITLE
add Readwise Daily Review preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ By default, Custom Frames comes with a few presets that allow you to get new pan
 - [Todoist](https://todoist.com), optimized for a narrow (half-height) side panel by removing some buttons and slimming margins.
 - [Notion](https://www.notion.so/) (it's recommended to close Notion's sidebar if used as a side pane)
 - [Twitter](https://twitter.com)
+- [Readwise Daily Review](https://readwise.io/dailyreview)
 
 If you create a frame that you think other people would like, don't hesitate to create a pull request with [a new preset](https://github.com/Ellpeck/ObsidianCustomFrames/blob/master/src/settings.ts#L5).
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -134,7 +134,19 @@ html > body > div:first-child > header:first-child > div > div:first-child > div
         forceIframe: false,
         customCss: "",
         customJs: ""
-    }
+    },
+    "readwise-daily-review": {
+        "url": "https://readwise.io/dailyreview",
+        "displayName": "Readwise Daily Review",
+        "icon": "highlighter",
+        "hideOnMobile": true,
+        "addRibbonIcon": false,
+        "openInCenter": false,
+        "zoomLevel": 1,
+        "forceIframe": false,
+        "customCss": "",
+        "customJs": ""
+    },
 };
 
 export interface CustomFramesSettings {


### PR DESCRIPTION
Adds a [Readwise Daily Review](https://readwise.io/dailyreview) preset.

Created since my usual flow involves going through my highlights via daily review and integrating them into my notes. Works really well since all highlights have been exported to Obsidian by the [Readwise Official Obsidian plugin](https://github.com/readwiseio/obsidian-readwise).

![image](https://github.com/tyler-dot-earth/dev-ObsidianCustomFrames/assets/595711/74cab649-3415-4588-b77b-95da10ee7ca5)
